### PR TITLE
Fix double encoding for link parameters separator

### DIFF
--- a/taglib/src/main/java/org/apache/struts/taglib/html/LinkTag.java
+++ b/taglib/src/main/java/org/apache/struts/taglib/html/LinkTag.java
@@ -443,7 +443,7 @@ public class LinkTag extends BaseHandlerTag {
 
         try {
             url = TagUtils.getInstance().computeURLWithCharEncoding(pageContext,
-                    forward, href, page, action, module, params, anchor, false,
+                    forward, href, page, action, module, params, anchor, false,false,
                     useLocalEncoding);
         } catch (MalformedURLException e) {
             TagUtils.getInstance().saveException(pageContext, e);


### PR DESCRIPTION
the link parameters separator & is encoded twice : first in computeURLWithCharEncoding then a second time when the link is handled by prepareAttribute that will call filter on it