### PR TITLE
Add filtering for Option text

### DIFF
--- a/taglib/src/main/java/org/apache/struts/taglib/html/OptionTag.java
+++ b/taglib/src/main/java/org/apache/struts/taglib/html/OptionTag.java
@@ -334,7 +334,7 @@ public class OptionTag extends BodyTagSupport {
 
         results.append(">");
 
-        results.append(text());
+        results.append(TagUtils.getInstance().filter(text()));
 
         results.append("</option>");
 


### PR DESCRIPTION
We found that option label (called text) was rendered but not filtered.